### PR TITLE
Restyle homepage with muted professional theme

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,8 @@ import HomePage from './pages/HomePage';
 import RegisterPage from './pages/RegisterPage';
 import PatientProfile from './pages/PatientProfile';
 import SignInPage from './pages/SignInPage';
-import Header from './components/Header';
+import Header from './components/layout/Header';
+import Footer from './components/layout/Footer';
 import BookAppointmentPage from './pages/BookAppointmentPage';
 import StaffPortal from './pages/StaffPortal';
 import { AuthContext } from './AuthContext';
@@ -15,9 +16,12 @@ function App() {
 
   return (
     <Router basename="/Capstone-Project">
-      <div className="relative flex min-h-screen flex-col bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950">
+      <div className="relative flex min-h-screen flex-col">
+        <div className="pointer-events-none fixed inset-0 -z-10">
+          <div className="absolute inset-0 bg-white/70 dark:bg-white/60" />
+        </div>
         <Header />
-        <main className="flex-1 px-4 pb-12 pt-28 sm:px-8">
+        <main className="flex-1 px-4 pb-16 pt-28 sm:px-6 lg:px-10">
           <Routes>
             <Route path="/" element={<HomePage />} />
             <Route path="/register" element={<RegisterPage />} />
@@ -41,6 +45,7 @@ function App() {
             <Route path="*" element={<Navigate to="/" />} />
           </Routes>
         </main>
+        <Footer />
       </div>
     </Router>
   );

--- a/src/components/layout/Footer.jsx
+++ b/src/components/layout/Footer.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { FaCcMastercard, FaCcVisa, FaCcAmex, FaUniversity } from 'react-icons/fa';
+
+const payments = [
+  { label: 'Visa', icon: <FaCcVisa /> },
+  { label: 'Mastercard', icon: <FaCcMastercard /> },
+  { label: 'American Express', icon: <FaCcAmex /> },
+  { label: 'Bank Transfer', icon: <FaUniversity /> },
+];
+
+function Footer() {
+  return (
+    <footer className="border-t border-slate-200/80 bg-white/85 backdrop-blur dark:border-slate-300/60 dark:bg-white/80">
+      <div className="mx-auto flex max-w-6xl flex-col gap-8 px-4 py-12 text-slate-600 dark:text-slate-700 sm:flex-row sm:items-start sm:justify-between sm:px-6 lg:px-8">
+        <div className="space-y-4">
+          <h2 className="text-2xl font-semibold text-brand-primary">Destination Health</h2>
+          <p className="max-w-sm text-sm leading-relaxed">
+            Delivering compassionate care through intuitive technology. We connect patients with the right clinicians at the right moment.
+          </p>
+          <div>
+            <h3 className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">Location</h3>
+            <p className="mt-2 text-sm">123 Wellness Avenue, Suite 500, Harmony City, HC 45678</p>
+          </div>
+        </div>
+        <div className="space-y-4">
+          <h3 className="text-xs font-semibold uppercase tracking-[0.25em] text-slate-400">Payments we accept</h3>
+          <div className="flex flex-wrap items-center gap-4 text-3xl text-brand-primary">
+            {payments.map((payment) => (
+              <span key={payment.label} className="flex items-center gap-2">
+                {payment.icon}
+                <span className="sr-only">{payment.label}</span>
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+      <div className="border-t border-slate-200/80 bg-white/75 py-4 text-center text-xs text-slate-400 dark:text-slate-500">
+        © {new Date().getFullYear()} Destination Health. All rights reserved.
+      </div>
+    </footer>
+  );
+}
+
+export default Footer;

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -1,10 +1,11 @@
 import React, { useContext, useState, useRef, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { AuthContext } from '../AuthContext';
-import { FaUserCircle, FaBars, FaTimes } from 'react-icons/fa';
+import { FaBars, FaTimes, FaUserCircle } from 'react-icons/fa';
+import { AuthContext } from '../../AuthContext';
+import ThemeToggle from '../ui/ThemeToggle';
 
 const navLinkClasses =
-  'rounded-md px-3 py-2 text-sm font-medium text-white transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900';
+  'rounded-full px-3 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-100 hover:text-brand-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:text-slate-700 dark:hover:bg-white/80 dark:focus-visible:ring-offset-slate-200';
 
 function Header() {
   const { auth, logout } = useContext(AuthContext);
@@ -12,14 +13,6 @@ function Header() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const dropdownRef = useRef(null);
   const navigate = useNavigate();
-
-  const toggleDropdown = () => {
-    setDropdownOpen((prev) => !prev);
-  };
-
-  const toggleMobileMenu = () => {
-    setMobileMenuOpen((prev) => !prev);
-  };
 
   useEffect(() => {
     const handleClickOutside = (event) => {
@@ -32,6 +25,15 @@ function Header() {
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, []);
 
+  const toggleDropdown = () => {
+    setDropdownOpen((prev) => !prev);
+  };
+
+  const toggleMobileMenu = () => {
+    setMobileMenuOpen((prev) => !prev);
+    setDropdownOpen(false);
+  };
+
   const handleLogout = () => {
     logout();
     navigate('/');
@@ -40,23 +42,23 @@ function Header() {
   };
 
   return (
-    <header className="fixed inset-x-0 top-0 z-50 bg-slate-900 text-white shadow-lg">
-      <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-4 sm:px-6">
+    <header className="fixed inset-x-0 top-0 z-50 border-b border-slate-200/80 bg-white/85 backdrop-blur dark:border-slate-300/60 dark:bg-white/80">
+      <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-4 text-slate-700 sm:px-6">
         <Link
           to="/"
-          className="text-2xl font-semibold tracking-tight text-white transition hover:text-brand-accent"
+          className="text-2xl font-semibold tracking-tight text-brand-primary transition hover:text-slate-900"
           onClick={() => setMobileMenuOpen(false)}
         >
           Destination Health
         </Link>
 
-        <div className="flex items-center gap-4 sm:gap-6">
+        <div className="flex items-center gap-3 sm:gap-5">
           <nav className="hidden items-center gap-2 md:flex">
             <Link to="/" className={navLinkClasses}>
               Home
             </Link>
-            <a href="#how-to-book" className={navLinkClasses}>
-              How to Book
+            <a href="#services" className={navLinkClasses}>
+              Services
             </a>
             <Link to="/about-us" className={navLinkClasses}>
               About Us
@@ -68,27 +70,27 @@ function Header() {
               <div className="relative" ref={dropdownRef}>
                 <button
                   type="button"
-                  className={`${navLinkClasses} flex items-center gap-2`}
+                  className={`${navLinkClasses} flex items-center gap-2 bg-white/80 text-slate-600 shadow-sm hover:bg-white`}
                   onClick={toggleDropdown}
                   aria-haspopup="true"
                   aria-expanded={dropdownOpen}
                 >
-                  <FaUserCircle className="text-lg" />
+                  <FaUserCircle className="text-lg text-brand-primary" />
                   Profile
-                  <span className="text-xs">&#9662;</span>
+                  <span className="text-xs text-slate-400">&#9662;</span>
                 </button>
                 {dropdownOpen && (
-                  <div className="absolute right-0 mt-2 w-48 rounded-lg border border-slate-700 bg-slate-900/95 p-2 shadow-xl">
+                  <div className="absolute right-0 mt-3 w-60 rounded-2xl border border-slate-200/70 bg-white/95 p-4 shadow-xl dark:border-slate-300/60 dark:bg-white/95">
                     <Link
                       to="/myprofile"
-                      className="block rounded-md px-3 py-2 text-sm text-white transition hover:bg-white/10"
+                      className="block rounded-full px-4 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-100"
                       onClick={() => setDropdownOpen(false)}
                     >
                       View Profile
                     </Link>
                     <button
                       type="button"
-                      className="mt-1 w-full rounded-md px-3 py-2 text-left text-sm font-semibold text-red-200 transition hover:bg-red-500/20"
+                      className="mt-3 w-full rounded-full bg-slate-100 px-4 py-2 text-left text-sm font-semibold text-slate-600 transition hover:bg-slate-200"
                       onClick={handleLogout}
                     >
                       Log Out
@@ -99,16 +101,18 @@ function Header() {
             ) : (
               <Link
                 to="/signin"
-                className="rounded-md bg-brand-accent px-4 py-2 text-sm font-semibold text-white shadow hover:bg-sky-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900"
+                className="rounded-full bg-brand-primary px-5 py-2 text-sm font-semibold text-white shadow-sm transition hover:-translate-y-0.5 hover:bg-brand-primary/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent focus-visible:ring-offset-2 focus-visible:ring-offset-white"
               >
                 Sign In
               </Link>
             )}
           </nav>
 
+          <ThemeToggle className="hidden md:inline-flex" />
+
           <button
             type="button"
-            className="inline-flex items-center justify-center rounded-md p-2 text-white transition hover:bg-white/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 md:hidden"
+            className="inline-flex items-center justify-center rounded-full border border-slate-200/80 bg-white/80 p-2 text-slate-600 shadow-sm transition hover:-translate-y-0.5 hover:bg-white focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent focus-visible:ring-offset-2 focus-visible:ring-offset-white md:hidden"
             onClick={toggleMobileMenu}
             aria-label="Toggle menu"
           >
@@ -118,8 +122,8 @@ function Header() {
       </div>
 
       {mobileMenuOpen && (
-        <div className="border-t border-slate-800 bg-slate-900/95 px-4 pb-4 pt-2 shadow-lg md:hidden">
-          <nav className="flex flex-col gap-2">
+        <div className="border-t border-slate-200/80 bg-white/90 px-4 pb-6 pt-3 shadow-lg backdrop-blur md:hidden">
+          <nav className="flex flex-col gap-3">
             <Link
               to="/"
               className={navLinkClasses}
@@ -128,11 +132,11 @@ function Header() {
               Home
             </Link>
             <a
-              href="#how-to-book"
+              href="#services"
               className={navLinkClasses}
               onClick={() => setMobileMenuOpen(false)}
             >
-              How to Book
+              Services
             </a>
             <Link
               to="/about-us"
@@ -152,7 +156,7 @@ function Header() {
               <div className="flex flex-col gap-2" ref={dropdownRef}>
                 <Link
                   to="/myprofile"
-                  className={navLinkClasses}
+                  className={`${navLinkClasses} bg-white text-slate-600`}
                   onClick={() => {
                     setDropdownOpen(false);
                     setMobileMenuOpen(false);
@@ -162,7 +166,7 @@ function Header() {
                 </Link>
                 <button
                   type="button"
-                  className="rounded-md bg-red-500/90 px-3 py-2 text-left text-sm font-semibold text-white shadow hover:bg-red-500"
+                  className="rounded-full bg-slate-100 px-4 py-2 text-left text-sm font-semibold text-slate-600 transition hover:bg-slate-200"
                   onClick={handleLogout}
                 >
                   Log Out
@@ -171,7 +175,7 @@ function Header() {
             ) : (
               <Link
                 to="/signin"
-                className="rounded-md bg-brand-accent px-3 py-2 text-sm font-semibold text-white shadow hover:bg-sky-500"
+                className="rounded-full bg-brand-primary px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:-translate-y-0.5 hover:bg-brand-primary/90"
                 onClick={() => setMobileMenuOpen(false)}
               >
                 Sign In

--- a/src/components/ui/ThemeToggle.jsx
+++ b/src/components/ui/ThemeToggle.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { FaMoon, FaSun } from 'react-icons/fa';
+import { useTheme } from '../../theme/ThemeContext';
+
+function ThemeToggle({ className = '' }) {
+  const { theme, toggleTheme } = useTheme();
+  const isDark = theme === 'dark';
+
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      className={`inline-flex items-center gap-2 rounded-full border border-slate-200/70 bg-white/80 px-4 py-2 text-sm font-medium text-slate-600 shadow-sm transition hover:-translate-y-0.5 hover:bg-white focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-slate-300/70 dark:bg-white/80 dark:text-slate-700 ${className}`}
+      aria-label="Toggle color theme"
+    >
+      {isDark ? <FaSun className="text-brand-primary" /> : <FaMoon className="text-brand-primary" />}
+      <span className="hidden sm:inline">{isDark ? 'Light mode' : 'Dark mode'}</span>
+    </button>
+  );
+}
+
+export default ThemeToggle;

--- a/src/index.css
+++ b/src/index.css
@@ -4,11 +4,23 @@
 
 @layer base {
   html {
-    @apply min-h-full bg-slate-100;
+    @apply min-h-full scroll-smooth;
   }
 
   body {
-    @apply min-h-full text-slate-900 font-sans antialiased bg-gradient-to-br from-slate-100 via-white to-slate-200;
+    @apply min-h-full font-sans antialiased text-slate-900 transition-colors duration-300 ease-in-out;
+    background-color: #f6f7f8;
+    background-image: linear-gradient(135deg, rgba(247, 248, 250, 0.96), rgba(233, 236, 239, 0.96)),
+      url('https://images.unsplash.com/photo-1526256262350-7da7584cf5eb?auto=format&fit=crop&w=1920&q=80');
+    background-attachment: fixed;
+    background-size: cover;
+    background-repeat: no-repeat;
+  }
+
+  html.dark body {
+    @apply bg-slate-100 text-slate-900;
+    background-image: linear-gradient(135deg, rgba(240, 242, 245, 0.94), rgba(226, 230, 235, 0.94)),
+      url('https://images.unsplash.com/photo-1526256262350-7da7584cf5eb?auto=format&fit=crop&w=1920&q=80');
   }
 
   #root {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -6,13 +6,16 @@ import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 import { AuthProvider } from './AuthContext'; // Import AuthProvider
+import { ThemeProvider } from './theme/ThemeContext';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <AuthProvider> {/* Wrap App with AuthProvider */}
-      <App />
-    </AuthProvider>
+    <ThemeProvider>
+      <AuthProvider> {/* Wrap App with AuthProvider */}
+        <App />
+      </AuthProvider>
+    </ThemeProvider>
   </React.StrictMode>
 );
 

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,263 +1,207 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
-import { FaUserMd, FaShieldAlt, FaHeartbeat, FaClock, FaMobileAlt, FaCalendarCheck } from 'react-icons/fa';
+import { FaCalendarCheck, FaHeartbeat, FaShieldAlt, FaUserMd } from 'react-icons/fa';
 
-const quickActions = [
-  {
-    title: 'New Patient',
-    description: 'Create your profile, share your medical history, and get matched with the right doctor in minutes.',
-    cta: { label: 'Register Now', to: '/register' },
-    icon: <FaHeartbeat className="text-xl" />,
-  },
-  {
-    title: 'Returning Patient',
-    description: 'Securely sign in to manage appointments, update records, and message your care team.',
-    cta: { label: 'Access Portal', to: '/signin' },
-    icon: <FaCalendarCheck className="text-xl" />,
-  },
+const statistics = [
+  { label: 'Clinicians in our network', value: '180+' },
+  { label: 'Average confirmation time', value: '90 mins' },
+  { label: 'Patient satisfaction', value: '98%' },
 ];
 
-const serviceHighlights = [
+const services = [
   {
     icon: <FaUserMd />,
-    title: 'Personalized Care',
-    description: 'Choose from a network of trusted family doctors and specialists tailored to your needs.',
+    title: 'Personalised doctor matching',
+    description: 'Search by specialty, availability, and bedside manner to find the clinician who fits your expectations.',
   },
   {
-    icon: <FaClock />,
-    title: 'Real-Time Availability',
-    description: 'Browse open appointments instantly and pick the time that works best for your schedule.',
+    icon: <FaCalendarCheck />,
+    title: 'Appointments without friction',
+    description: 'Reserve visits in a few steps, sync them with your calendar, and receive timely confirmations every time.',
   },
   {
     icon: <FaShieldAlt />,
-    title: 'Secure Health Records',
-    description: 'Your information is encrypted and protected, giving you peace of mind every time you log in.',
-  },
-  {
-    icon: <FaMobileAlt />,
-    title: 'Care On-The-Go',
-    description: 'Manage your appointments and reminders from any device with our fully responsive experience.',
+    title: 'Secure, unified records',
+    description: 'Documents and notes are stored with hospital-grade security so you can share the right details with ease.',
   },
 ];
 
-const bookingSteps = [
+const workflow = [
   {
-    step: '01',
-    title: 'Create Your Profile',
-    description: 'Tell us about your medical history and preferences so we can connect you with the best provider.',
+    title: 'Share your priorities',
+    description: 'Create a profile, outline your care goals, and let us tailor recommendations to your needs.',
   },
   {
-    step: '02',
-    title: 'Choose a Doctor',
-    description: 'Browse vetted professionals, read reviews, and select the doctor that feels right for you.',
+    title: 'Review curated options',
+    description: 'Compare clinicians, availability, and experience presented in a clear, distraction-free view.',
   },
   {
-    step: '03',
-    title: 'Book & Confirm',
-    description: 'Pick a convenient time, receive instant confirmation, and add it to your calendar in one tap.',
+    title: 'Confirm with confidence',
+    description: 'Secure your visit, receive confirmations instantly, and stay informed with thoughtful reminders.',
   },
 ];
 
 const testimonials = [
   {
-    name: 'Sophie L.',
-    role: 'Chronic Care Patient',
     quote:
-      '“I love how easy it is to find open appointments that fit my schedule. Destination Health keeps every detail organized.”',
-  },
-  {
-    name: 'Marcus R.',
-    role: 'Caregiver',
-    quote:
-      '“Managing my father’s appointments used to be stressful. Now I can track everything from reminders to prescriptions in one place.”',
-  },
-  {
+      'Destination Health brings welcome clarity to our scheduling. Patients arrive calm, prepared, and on time.',
     name: 'Dr. Evelyn Park',
     role: 'Family Physician',
-    quote:
-      '“The portal streamlines communication with patients and helps our team reduce wait times dramatically.”',
   },
-];
-
-const stats = [
-  { label: 'Average Wait Time', value: '2.5 days' },
-  { label: 'Doctors in Network', value: '180+' },
-  { label: 'Patient Satisfaction', value: '98%' },
+  {
+    quote: 'The platform keeps my family organised. Booking follow-ups takes minutes and the reminders are discreet.',
+    name: 'Sophie Laurent',
+    role: 'Parent and caregiver',
+  },
 ];
 
 function HomePage() {
   const navigate = useNavigate();
 
   return (
-    <div className="relative mx-auto flex w-full max-w-6xl flex-col gap-16 px-4 pb-20 text-slate-100 sm:px-6 lg:px-8">
-      <div className="pointer-events-none absolute inset-0 -z-10">
-        <div className="absolute -left-32 top-24 h-72 w-72 rounded-full bg-brand-primary/30 blur-3xl" />
-        <div className="absolute -right-24 top-64 h-96 w-96 rounded-full bg-brand-accent/20 blur-3xl" />
-        <div className="absolute bottom-0 left-1/2 h-64 w-64 -translate-x-1/2 rounded-full bg-white/10 blur-3xl" />
-      </div>
-
-      <section className="rounded-[2rem] border border-white/20 bg-white/10 px-8 py-14 shadow-[0_25px_60px_-40px_rgba(15,23,42,0.75)] backdrop-blur-2xl lg:grid lg:grid-cols-[3fr,2fr] lg:items-center lg:gap-12">
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-16 px-4 text-slate-600 sm:px-6 lg:px-8">
+      <section className="grid gap-10 rounded-3xl border border-slate-200/80 bg-white/90 p-10 shadow-[0_18px_40px_-28px_rgba(15,23,42,0.45)] md:grid-cols-[1.15fr_1fr] md:items-center dark:border-slate-300/70 dark:bg-white/85">
         <div className="space-y-8">
-          <span className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-sky-100">
-            Trusted Digital Health Hub
-          </span>
-          <div className="space-y-6">
-            <h1 className="text-3xl font-semibold leading-tight text-white sm:text-4xl lg:text-5xl">
-              Book doctor appointments with clarity and confidence.
+          <div className="space-y-3">
+            <span className="inline-flex items-center rounded-full border border-slate-200/80 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-brand-primary">
+              Private & focused care
+            </span>
+            <h1 className="text-4xl font-semibold leading-tight text-slate-900 sm:text-5xl">
+              A composed way to arrange care, trusted by patients and clinicians alike.
             </h1>
-            <p className="max-w-xl text-base leading-relaxed text-sky-100 sm:text-lg">
-              Destination Health brings your care team, health history, and appointment booking together in one secure, intuitive portal so you can focus on feeling your best.
+            <p className="max-w-2xl text-base leading-relaxed text-slate-600">
+              Destination Health simplifies every appointment with measured design. Explore an extensive clinical network, confirm visits swiftly, and rely on a platform built for discretion and dependability.
             </p>
           </div>
 
-          <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+          <div className="flex flex-col gap-3 text-sm text-slate-600 sm:flex-row sm:items-center sm:gap-6">
+            <div className="flex items-center gap-2">
+              <FaHeartbeat className="text-brand-primary" />
+              <span>Dedicated to preventative and primary care journeys.</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <FaShieldAlt className="text-brand-primary" />
+              <span>Data stewardship that respects your privacy.</span>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-4 sm:flex-row">
             <button
               type="button"
               onClick={() => navigate('/book-appointment')}
-              className="w-full rounded-full bg-brand-primary px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-brand-primary/40 transition hover:-translate-y-0.5 hover:bg-blue-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 sm:w-auto"
+              className="inline-flex items-center justify-center rounded-full bg-brand-primary px-7 py-3 text-sm font-semibold text-white shadow-sm transition hover:-translate-y-0.5 hover:bg-brand-primary/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent focus-visible:ring-offset-2 focus-visible:ring-offset-white"
             >
-              Book Appointment
+              Book an appointment
             </button>
             <button
               type="button"
               onClick={() => navigate('/about-us')}
-              className="w-full rounded-full border border-white/30 bg-white/10 px-6 py-3 text-sm font-semibold text-white backdrop-blur transition hover:-translate-y-0.5 hover:bg-white/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-slate-900 sm:w-auto"
+              className="inline-flex items-center justify-center rounded-full border border-slate-300 bg-white px-7 py-3 text-sm font-semibold text-slate-700 transition hover:-translate-y-0.5 hover:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent focus-visible:ring-offset-2 focus-visible:ring-offset-white"
             >
-              Learn More
+              Meet our team
             </button>
           </div>
+        </div>
 
-          <div className="grid gap-4 text-sm text-slate-100 sm:grid-cols-3">
-            {stats.map((item) => (
-              <div
-                key={item.label}
-                className="rounded-2xl border border-white/20 bg-white/10 px-5 py-4 text-center shadow-inner backdrop-blur"
-              >
-                <p className="text-lg font-semibold text-white sm:text-xl">{item.value}</p>
-                <p className="mt-1 text-xs uppercase tracking-wide text-sky-100/80">{item.label}</p>
+        <div className="space-y-6 rounded-3xl border border-slate-200/80 bg-white/85 p-8 text-slate-600 shadow-inner dark:border-slate-300/70 dark:bg-white/80">
+          <p className="text-lg font-medium text-slate-900">
+            "Our ambition is to make clinical coordination feel gracious. Every interaction should balance efficiency with warmth."
+          </p>
+          <div className="grid gap-4 sm:grid-cols-3">
+            {statistics.map((stat) => (
+              <div key={stat.label} className="rounded-2xl border border-slate-200/80 bg-white/80 p-4 text-center">
+                <p className="text-xl font-semibold text-brand-primary">{stat.value}</p>
+                <p className="mt-1 text-xs uppercase tracking-[0.25em] text-slate-400">{stat.label}</p>
               </div>
             ))}
           </div>
         </div>
+      </section>
 
-        <div className="mt-10 space-y-4 lg:mt-0">
-          {quickActions.map((action) => (
-            <article
-              key={action.title}
-              className="flex flex-col gap-3 rounded-3xl border border-white/20 bg-white/10 px-6 py-5 shadow-[0_10px_30px_-25px_rgba(15,23,42,0.8)] backdrop-blur"
-            >
-              <div>
-                <div className="flex items-center gap-3">
-                  <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-brand-primary/30 text-white">
-                    {action.icon}
-                  </span>
-                  <h2 className="text-lg font-semibold text-white">{action.title}</h2>
-                </div>
-                <p className="mt-2 text-sm text-sky-100">{action.description}</p>
+      <section id="services" className="space-y-8 rounded-3xl border border-slate-200/80 bg-white/90 p-10 shadow-[0_18px_40px_-28px_rgba(15,23,42,0.45)] dark:border-slate-300/70 dark:bg-white/85">
+        <div className="space-y-3 text-center">
+          <h2 className="text-3xl font-semibold text-slate-900 sm:text-4xl">Services designed for clarity</h2>
+          <p className="mx-auto max-w-2xl text-sm text-slate-600">
+            Each touchpoint has been considered so appointments, records, and communication remain orderly for every member of the care team.
+          </p>
+        </div>
+        <div className="grid gap-6 md:grid-cols-3">
+          {services.map((service) => (
+            <article key={service.title} className="flex h-full flex-col gap-4 rounded-3xl border border-slate-200/80 bg-white/85 p-6 text-left transition hover:-translate-y-1 hover:shadow-[0_20px_45px_-30px_rgba(15,23,42,0.55)]">
+              <div className="inline-flex h-12 w-12 items-center justify-center rounded-full border border-slate-200/80 bg-white text-xl text-brand-primary">
+                {service.icon}
               </div>
-              <button
-                type="button"
-                onClick={() => navigate(action.cta.to)}
-                className="inline-flex items-center justify-center self-start rounded-full bg-brand-accent/90 px-5 py-2 text-xs font-semibold uppercase tracking-wide text-white shadow transition hover:-translate-y-0.5 hover:bg-sky-500"
-              >
-                {action.cta.label}
-              </button>
+              <div className="space-y-2">
+                <h3 className="text-lg font-semibold text-slate-900">{service.title}</h3>
+                <p className="text-sm leading-relaxed text-slate-600">{service.description}</p>
+              </div>
             </article>
           ))}
         </div>
       </section>
 
-      <section className="grid gap-8 rounded-[2rem] border border-white/20 bg-white/10 p-10 shadow-[0_25px_60px_-45px_rgba(15,23,42,0.8)] backdrop-blur-2xl" id="how-to-book">
-        <div className="flex flex-col gap-3 text-center">
-          <span className="text-xs font-semibold uppercase tracking-[0.4em] text-sky-100">How it works</span>
-          <h2 className="text-3xl font-semibold text-white sm:text-4xl">Book in three simple steps</h2>
-          <p className="mx-auto max-w-2xl text-sm text-sky-100 sm:text-base">
-            We combined intuitive design with clinical expertise so you can move from signup to scheduled appointment without the guesswork.
+      <section className="grid gap-8 rounded-3xl border border-slate-200/80 bg-white/90 p-10 shadow-[0_18px_40px_-28px_rgba(15,23,42,0.45)] dark:border-slate-300/70 dark:bg-white/85">
+        <div className="space-y-3 text-center">
+          <h2 className="text-3xl font-semibold text-slate-900 sm:text-4xl">A measured booking journey</h2>
+          <p className="mx-auto max-w-2xl text-sm text-slate-600">
+            Three concise stages help you move from intention to confirmation without haste.
           </p>
         </div>
-        <div className="grid gap-6 lg:grid-cols-3">
-          {bookingSteps.map((item) => (
-            <div
-              key={item.step}
-              className="relative overflow-hidden rounded-3xl border border-white/15 bg-white/10 px-8 py-10 shadow-lg backdrop-blur"
-            >
-              <span className="text-4xl font-semibold text-white/80">{item.step}</span>
-              <h3 className="mt-4 text-xl font-semibold text-white">{item.title}</h3>
-              <p className="mt-3 text-sm text-sky-100">{item.description}</p>
-              <div className="absolute -right-10 -top-10 h-28 w-28 rounded-full bg-brand-primary/20 blur-2xl" />
+        <div className="grid gap-6 md:grid-cols-3">
+          {workflow.map((step, index) => (
+            <div key={step.title} className="flex flex-col gap-4 rounded-3xl border border-slate-200/80 bg-white/85 p-6">
+              <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-slate-100 text-sm font-semibold text-brand-primary">
+                0{index + 1}
+              </span>
+              <div className="space-y-2">
+                <h3 className="text-lg font-semibold text-slate-900">{step.title}</h3>
+                <p className="text-sm leading-relaxed text-slate-600">{step.description}</p>
+              </div>
             </div>
           ))}
         </div>
       </section>
 
-      <section className="grid gap-8 rounded-[2rem] border border-white/20 bg-white/10 p-10 shadow-[0_25px_60px_-45px_rgba(15,23,42,0.8)] backdrop-blur-2xl">
-        <div className="flex flex-col gap-3 text-center">
-          <span className="text-xs font-semibold uppercase tracking-[0.4em] text-sky-100">Why patients choose us</span>
-          <h2 className="text-3xl font-semibold text-white sm:text-4xl">Designed for modern healthcare</h2>
-          <p className="mx-auto max-w-2xl text-sm text-sky-100 sm:text-base">
-            Destination Health empowers patients and providers with tools that anticipate needs, streamline communication, and improve outcomes.
+      <section className="grid gap-6 rounded-3xl border border-slate-200/80 bg-white/90 p-10 shadow-[0_18px_40px_-28px_rgba(15,23,42,0.45)] dark:border-slate-300/70 dark:bg-white/85">
+        <div className="space-y-3 text-center">
+          <h2 className="text-3xl font-semibold text-slate-900 sm:text-4xl">Perspectives from our community</h2>
+          <p className="mx-auto max-w-2xl text-sm text-slate-600">
+            Professional teams and families rely on Destination Health to keep their schedules deliberate and composed.
           </p>
         </div>
         <div className="grid gap-6 md:grid-cols-2">
-          {serviceHighlights.map((feature) => (
-            <article
-              key={feature.title}
-              className="flex flex-col gap-4 rounded-3xl border border-white/15 bg-white/10 p-8 text-left shadow-lg backdrop-blur"
-            >
-              <span className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-brand-primary/30 text-2xl text-white">
-                {feature.icon}
-              </span>
-              <div>
-                <h3 className="text-lg font-semibold text-white">{feature.title}</h3>
-                <p className="mt-2 text-sm text-sky-100">{feature.description}</p>
+          {testimonials.map((testimonial) => (
+            <blockquote key={testimonial.name} className="flex h-full flex-col justify-between gap-4 rounded-3xl border border-slate-200/80 bg-white/85 p-6 text-left">
+              <p className="text-sm leading-relaxed text-slate-600">“{testimonial.quote}”</p>
+              <div className="space-y-1">
+                <p className="text-sm font-semibold text-slate-900">{testimonial.name}</p>
+                <p className="text-xs uppercase tracking-[0.25em] text-slate-400">{testimonial.role}</p>
               </div>
-            </article>
+            </blockquote>
           ))}
         </div>
       </section>
 
-      <section className="rounded-[2rem] border border-white/20 bg-white/10 px-10 py-12 shadow-[0_25px_60px_-45px_rgba(15,23,42,0.8)] backdrop-blur-2xl">
-        <div className="flex flex-col gap-6 text-center">
-          <span className="text-xs font-semibold uppercase tracking-[0.4em] text-sky-100">What people say</span>
-          <h2 className="text-3xl font-semibold text-white sm:text-4xl">Real stories from patients & providers</h2>
-          <div className="grid gap-6 md:grid-cols-3">
-            {testimonials.map((testimonial) => (
-              <blockquote
-                key={testimonial.name}
-                className="flex h-full flex-col gap-4 rounded-3xl border border-white/15 bg-white/10 p-6 text-left shadow-lg backdrop-blur"
-              >
-                <p className="text-sm italic text-sky-100">{testimonial.quote}</p>
-                <div>
-                  <p className="text-sm font-semibold text-white">{testimonial.name}</p>
-                  <p className="text-xs uppercase tracking-wide text-sky-100/80">{testimonial.role}</p>
-                </div>
-              </blockquote>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      <section className="overflow-hidden rounded-[2rem] border border-white/20 bg-gradient-to-r from-brand-primary/80 via-brand-accent/80 to-sky-500/70 px-10 py-12 text-center shadow-[0_35px_70px_-45px_rgba(15,23,42,0.85)] backdrop-blur">
-        <div className="mx-auto flex max-w-3xl flex-col items-center gap-6">
-          <FaHeartbeat className="text-4xl text-white" />
-          <h2 className="text-3xl font-semibold text-white sm:text-4xl">Ready for a more connected care experience?</h2>
-          <p className="text-sm text-sky-100 sm:text-base">
-            Join thousands of patients who trust Destination Health to coordinate their appointments, records, and reminders with ease.
+      <section className="rounded-3xl border border-slate-200/80 bg-brand-primary px-8 py-12 text-white shadow-[0_18px_40px_-28px_rgba(15,23,42,0.65)]">
+        <div className="mx-auto flex max-w-3xl flex-col items-center gap-6 text-center">
+          <h2 className="text-3xl font-semibold sm:text-4xl">Let’s plan your next appointment thoughtfully</h2>
+          <p className="text-sm text-white/80 sm:text-base">
+            Join a service that values precision and discretion. Register in moments or begin by reviewing our clinicians.
           </p>
           <div className="flex flex-col gap-4 sm:flex-row">
             <button
               type="button"
-              onClick={() => navigate('/book-appointment')}
-              className="w-full rounded-full bg-white/90 px-6 py-3 text-sm font-semibold text-brand-primary shadow transition hover:-translate-y-0.5 hover:bg-white sm:w-auto"
+              onClick={() => navigate('/register')}
+              className="inline-flex items-center justify-center rounded-full bg-white/95 px-6 py-3 text-sm font-semibold text-brand-primary transition hover:-translate-y-0.5 hover:bg-white"
             >
-              Book Your Visit
+              Create your profile
             </button>
             <button
               type="button"
-              onClick={() => navigate('/register')}
-              className="w-full rounded-full border border-white/60 bg-white/10 px-6 py-3 text-sm font-semibold text-white backdrop-blur transition hover:-translate-y-0.5 hover:bg-white/20 sm:w-auto"
+              onClick={() => navigate('/book-appointment')}
+              className="inline-flex items-center justify-center rounded-full border border-white/70 px-6 py-3 text-sm font-semibold text-white transition hover:-translate-y-0.5 hover:bg-white/10"
             >
-              Create an Account
+              Book now
             </button>
           </div>
         </div>

--- a/src/theme/ThemeContext.jsx
+++ b/src/theme/ThemeContext.jsx
@@ -1,0 +1,72 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+
+const STORAGE_KEY = 'destination-health-theme';
+const prefersDark = () => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+};
+
+const defaultTheme = () => {
+  if (typeof window === 'undefined') {
+    return 'light';
+  }
+
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored === 'light' || stored === 'dark') {
+    return stored;
+  }
+
+  return prefersDark() ? 'dark' : 'light';
+};
+
+const ThemeContext = createContext({
+  theme: 'light',
+  toggleTheme: () => {},
+});
+
+export function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState(defaultTheme);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.remove(theme === 'light' ? 'dark' : 'light');
+    root.classList.add(theme);
+
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+
+    document.body.dataset.theme = theme;
+    localStorage.setItem(STORAGE_KEY, theme);
+  }, [theme]);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+    const listener = (event) => {
+      setTheme(event.matches ? 'dark' : 'light');
+    };
+    mediaQuery.addEventListener('change', listener);
+    return () => mediaQuery.removeEventListener('change', listener);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      theme,
+      toggleTheme: () => setTheme((prev) => (prev === 'light' ? 'dark' : 'light')),
+    }),
+    [theme],
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}
+
+export default ThemeContext;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: ["./src/**/*.{js,jsx,ts,tsx}", "./public/index.html"],
   theme: {
     extend: {
@@ -8,12 +9,15 @@ module.exports = {
       },
       colors: {
         brand: {
-          primary: '#1D4ED8',
-          accent: '#0EA5E9',
+          primary: '#1B2A3D',
+          accent: '#8C95A6',
+          secondary: '#B8A47A',
+          surface: '#F7F7F5',
+          darkSurface: '#E9ECEF',
         },
       },
       boxShadow: {
-        card: '0 10px 25px -15px rgba(15, 23, 42, 0.3)',
+        card: '0 18px 40px -20px rgba(15, 23, 42, 0.25)',
       },
     },
   },


### PR DESCRIPTION
## Summary
- reshape the homepage with neutral hero, services, workflow, and testimonial sections for a calmer presentation
- refresh the header, footer, theme toggle, and app backdrop to align with a light-first aesthetic in both themes
- retune the Tailwind brand palette and supporting styles to support the understated design system

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e06157a8ec8322804293448b6cd412